### PR TITLE
Performance fix when logging `req` or `res`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,9 @@ function logEvent(ctx, data, request) {
   } else if (ctx.includeData && data.data !== undefined) {
     if (ctx.mergeData) {
       try {
-        hoek.merge(obj, data.data);
+        // obj is much smaller than data in case data.data has req or res
+        // merging in this order is MUCH faster
+        obj = hoek.merge(data.data, obj);
 
         if (obj.id === obj.req_id) delete obj.id;
       } catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-bunyan",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "./lib",
   "description": "Simple Bunyan logging in Hapi",
   "dependencies": {


### PR DESCRIPTION
If the `data.data` object contains `req` or `res` the `hoek.merge` time took ~90ms, blocking the event loop and causing some serious damage to reqs/sec.

Since `obj` is smaller, merging the other way is way better perf wise.