### PR TITLE
Do not modify the passed in options object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,8 +65,7 @@ function register(server, options, next) {
   var handler = options.handler || function() {};
 
   options = lodash.defaults(
-    lodash.omit(options, ['logger', 'handler']), 
-    {
+    lodash.omit(options, ['logger', 'handler']), {
       includeTags: false,
       includeData: true,
       mergeData: false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,14 +64,13 @@ function register(server, options, next) {
   var log = options.logger;
   var handler = options.handler || function() {};
 
-  delete options.logger;
-  delete options.handler;
-
-  options = lodash.defaults(options, {
-    includeTags: false,
-    includeData: true,
-    mergeData: false,
-    skipUndefined: true,
+  options = lodash.defaults(
+    lodash.omit(options, ['logger', 'handler']), 
+    {
+      includeTags: false,
+      includeData: true,
+      mergeData: false,
+      skipUndefined: true,
   });
 
   var makeCtx = function(tags, level) {


### PR DESCRIPTION
I had a problem with my application tests, because I always used the same object to register this plugin. Digging deeper I noticed that this plugin modifies the passed in arguments.

In my opinion this is not a good practice especially if you do not own this object.