### PR TITLE
Added support for logging the request.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,10 @@ function logEvent(ctx, data, request) {
 
   if (request) obj.req_id = request.id;
 
+  if (ctx.serializers && ctx.serializers.req) {
+    obj.req = request;
+  }
+
   if (data instanceof Error) {
     ctx.log.child(obj)[ctx.level](data);
     return;


### PR DESCRIPTION
- Checks for a serializer for request
- If it's present, then it assigns request to req
- This is from the standard Bunyan set of serializers

Adding `serializers: bunyan.stdSerializers,` to your logger configuration will cause Bunyan's request serializer to be included and then request information will show up in your log objects.

This is very handy because otherwise you likely won't see where an error happened, especially for non-server errors.